### PR TITLE
Add deployment documentation and build scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Simple multi-stage Dockerfile for Next.js application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app /app
+EXPOSE 3000
+CMD ["npm","start"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,35 @@
+# Deployment Guide
+
+This document outlines how to deploy the application to common hosting providers and set up the required environment variables.
+
+## Hosting Options
+
+### Vercel
+Vercel offers a streamlined deployment experience for Next.js applications:
+1. [Create a Vercel account](https://vercel.com/signup) and install the Vercel CLI.
+2. Link this repository with `vercel` and follow the prompts.
+3. Configure environment variables (see below) in the Vercel dashboard.
+4. Vercel will build and deploy automatically on pushes to the default branch.
+
+### AWS
+You can deploy the container image to AWS services such as Elastic Container Service (ECS) or Elastic Kubernetes Service (EKS):
+1. Use the provided build script to create a Docker image.
+2. Push the image to Amazon Elastic Container Registry (ECR).
+3. Create an ECS service or EKS deployment referencing the image.
+4. Ensure the service runs the migration script during deployment.
+
+## Environment Setup
+
+1. Create a `.env` file in the project root.
+2. Define the following variables:
+   - `DATABASE_URL` – connection string for your database.
+   - `PORT` (optional) – port the server should listen on (defaults to `3000`).
+3. When deploying, make sure the environment variables are configured in your hosting platform.
+
+## Deployment Scripts
+
+Use the scripts in the `scripts/` directory to automate deployment tasks:
+- `scripts/build-image.sh` – builds a Docker image for the application.
+- `scripts/run-migrations.sh` – runs database migrations using Prisma.
+
+Ensure Docker and Node.js are installed on your deployment machine.

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="latest-os"
+IMAGE_TAG="${1:-latest}"
+
+docker build -t "$IMAGE_NAME:$IMAGE_TAG" .

--- a/scripts/run-migrations.sh
+++ b/scripts/run-migrations.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run database migrations in production
+npx prisma migrate deploy


### PR DESCRIPTION
## Summary
- document deployment options and environment setup
- add Dockerfile and scripts to build images and run Prisma migrations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts; build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a734e46270832a8111e9e89727706b