### PR TITLE
feat: add PWA manifest and service worker

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Leela OS",
+  "short_name": "Leela OS",
+  "start_url": "/",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/logo.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,41 @@
+// Simple service worker for caching critical assets
+const CACHE_NAME = "leela-os-cache-v1";
+const ASSETS_TO_CACHE = ["/", "/logo.svg", "/manifest.json"];
+
+self.addEventListener("install", event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener("activate", event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.map(key => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+});
+
+self.addEventListener("fetch", event => {
+  if (event.request.method !== "GET") return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request).then(response => {
+        const responseClone = response.clone();
+        caches
+          .open(CACHE_NAME)
+          .then(cache => cache.put(event.request, responseClone));
+        return response;
+      });
+    })
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import "./animations.css";
 import { Toaster } from "@/components/ui/toaster";
@@ -36,6 +37,7 @@ export const metadata: Metadata = {
     statusBarStyle: "default",
     title: "Leela OS",
   },
+  manifest: "/manifest.json",
 };
 
 export const viewport: Viewport = {
@@ -57,6 +59,15 @@ export default function RootLayout({
       >
         {children}
         <Toaster />
+        <Script id="service-worker-registration" strategy="afterInteractive">
+          {`
+            if ('serviceWorker' in navigator) {
+              window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/service-worker.js');
+              });
+            }
+          `}
+        </Script>
       </body>
     </html>
   );

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,48 @@
+// Simple service worker for caching critical assets
+
+// Ensure self is properly typed
+declare const self: ServiceWorkerGlobalScope;
+
+const CACHE_NAME = "leela-os-cache-v1";
+const ASSETS_TO_CACHE = ["/", "/logo.svg", "/manifest.json"];
+
+self.addEventListener("install", (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener("activate", (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+          return Promise.resolve();
+        })
+      )
+    )
+  );
+});
+
+self.addEventListener("fetch", (event: FetchEvent) => {
+  if (event.request.method !== "GET") return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request).then((response) => {
+        const responseClone = response.clone();
+        caches
+          .open(CACHE_NAME)
+          .then((cache) => cache.put(event.request, responseClone));
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest with icons and standalone display
- cache critical assets via a service worker
- register the service worker in the app layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a735763d40832aa2d45a775814ef5f