### PR TITLE
chore: enable lint rules and add prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run lint

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,49 +11,49 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends(
-    "next/core-web-vitals",
-    "next/typescript",
-    "plugin:jsx-a11y/recommended"
+    'next/core-web-vitals',
+    'next/typescript',
+    'plugin:jsx-a11y/recommended',
   ),
   {
     rules: {
       // TypeScript 相关规则
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-non-null-assertion": "off",
-      "@typescript-eslint/ban-ts-comment": "off",
-      "@typescript-eslint/prefer-as-const": "off",
-      
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/prefer-as-const': 'off',
+
       // React 相关规则
-      "react-hooks/exhaustive-deps": "off",
-      "react/no-unescaped-entities": "off",
-      "react/display-name": "off",
-      "react/prop-types": "off",
-      
+      'react-hooks/exhaustive-deps': 'off',
+      'react/no-unescaped-entities': 'off',
+      'react/display-name': 'off',
+      'react/prop-types': 'off',
+
       // Next.js 相关规则
-      "@next/next/no-img-element": "off",
-      "@next/next/no-html-link-for-pages": "off",
-      
+      '@next/next/no-img-element': 'off',
+      '@next/next/no-html-link-for-pages': 'off',
+
       // 一般JavaScript规则
-      "prefer-const": "off",  // 关闭prefer-const规则
-      "no-unused-vars": "off",
-      "no-console": "off",
-      "no-debugger": "off",
-      "no-empty": "off",
-      "no-irregular-whitespace": "off",
-      "no-case-declarations": "off",
-      "no-fallthrough": "off",
-      "no-mixed-spaces-and-tabs": "off",
-      "no-redeclare": "off",
-      "no-undef": "off",
-      "no-unreachable": "off",
-      "no-useless-escape": "off",
+      'prefer-const': 'error',
+      'no-unused-vars': 'error',
+      'no-console': 'off',
+      'no-debugger': 'off',
+      'no-empty': 'off',
+      'no-irregular-whitespace': 'off',
+      'no-case-declarations': 'off',
+      'no-fallthrough': 'off',
+      'no-mixed-spaces-and-tabs': 'off',
+      'no-redeclare': 'off',
+      'no-undef': 'off',
+      'no-unreachable': 'off',
+      'no-useless-escape': 'off',
       // Accessibility warnings
-      "jsx-a11y/label-has-associated-control": "warn",
-      "jsx-a11y/click-events-have-key-events": "warn",
-      "jsx-a11y/no-static-element-interactions": "warn",
-      "jsx-a11y/media-has-caption": "warn",
-      "jsx-a11y/anchor-has-content": "warn",
+      'jsx-a11y/label-has-associated-control': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'warn',
+      'jsx-a11y/no-static-element-interactions': 'warn',
+      'jsx-a11y/media-has-caption': 'warn',
+      'jsx-a11y/anchor-has-content': 'warn',
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -1,15 +1,34 @@
-51 ...
-"devDependencies": {
-  "@eslint/eslintrc": "^3",
-  "@storybook/addon-viewport": "^9.0.8",
-  "@storybook/nextjs": "^9.1.3",
-  "@storybook/react": "^9.1.3",
-  "@tailwindcss/postcss": "^4",
-  "@testing-library/jest-dom": "^6.8.0",
-  "@testing-library/react": "^16.3.0",
-  "@testing-library/user-event": "^14.6.1",
-  "@types/jest": "^30.0.0",
-  "@types/node": "^20",
-  "@types/react": "^19",
-  "@types/react-dom": "^19"
+{
+  "name": "latest-os",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "echo \"No tests\""
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3",
+    "@storybook/addon-viewport": "^9.0.8",
+    "@storybook/nextjs": "^9.1.3",
+    "@storybook/react": "^9.1.3",
+    "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^8.57.0",
+    "prettier": "^3.3.3",
+    "eslint-config-next": "^14.2.3",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.34.2",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.1",
+    "@typescript-eslint/parser": "^8.0.1",
+    "typescript": "^5.5.4"
+  }
 }


### PR DESCRIPTION
## Summary
- enforce `no-unused-vars` and `prefer-const` in ESLint config
- add Prettier configuration and npm scripts
- ensure CI fails on lint problems

## Testing
- `npm test`
- `npm run lint` *(fails: "696 problems (646 errors, 50 warnings)")*
- `npm run format:check` *(fails: "Code style issues found in 173 files. Run Prettier with --write to fix.")*


------
https://chatgpt.com/codex/tasks/task_e_68a73b880138832ab22664b3f9a1be07