### PR TITLE
Add database backup and restore scripts with operations guide

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,47 @@
+# Operations Guide
+
+## Nightly Database Backups
+
+Use `scripts/backup-db.sh` to create a nightly dump of the production database and store it in object storage.
+
+1. Ensure `pg_dump` and the AWS CLI are installed.
+2. Set the following environment variables:
+   - `DATABASE_URL` – connection string for the database.
+   - `S3_BUCKET` – destination bucket for backups.
+3. Schedule the script via cron:
+   ```cron
+   0 2 * * * /path/to/repo/scripts/backup-db.sh
+   ```
+   This example runs the backup at 02:00 every day.
+
+Backups are stored in `s3://$S3_BUCKET/db-backups/` with a timestamped filename.
+
+## Restoring from Backup
+
+`scripts/restore-db.sh` retrieves a dump from S3 and pipes it into the database.
+
+```bash
+scripts/restore-db.sh                     # restore the latest backup
+scripts/restore-db.sh 20240101120000.sql.gz  # restore a specific backup
+```
+
+## Media Upload Versioning
+
+Media uploads should be stored in an object storage bucket with versioning enabled.
+
+1. Create a bucket for media uploads and enable versioning:
+   ```bash
+   aws s3api put-bucket-versioning --bucket "$MEDIA_BUCKET" --versioning-configuration Status=Enabled
+   ```
+2. Configure the application to upload media to `s3://$MEDIA_BUCKET/`.
+3. Keeping versioning enabled protects against accidental deletions or overwrites.
+
+## Recovery Tests
+
+On the first business day of each month:
+
+1. Download the most recent backup using `scripts/restore-db.sh` into a staging environment.
+2. Verify the application runs correctly against the restored data.
+3. Document the test results for audit purposes.
+
+Regular recovery tests ensure backups are valid and the restore process is reliable.

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dump the production database and upload to S3
+# Requires: pg_dump, aws cli, DATABASE_URL, and S3_BUCKET env vars
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+
+if [[ -z "${S3_BUCKET:-}" ]]; then
+  echo "S3_BUCKET is required" >&2
+  exit 1
+fi
+
+timestamp=$(date +%Y%m%d%H%M%S)
+backup_file="/tmp/db-$timestamp.sql.gz"
+
+pg_dump "$DATABASE_URL" | gzip > "$backup_file"
+aws s3 cp "$backup_file" "s3://$S3_BUCKET/db-backups/$timestamp.sql.gz"
+rm "$backup_file"

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore the production database from a backup stored in S3
+# Usage: restore-db.sh [backup-file]
+# If no file is provided, the most recent backup is restored.
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+
+if [[ -z "${S3_BUCKET:-}" ]]; then
+  echo "S3_BUCKET is required" >&2
+  exit 1
+fi
+
+key=${1:-latest}
+
+tmpfile="/tmp/db-restore.sql.gz"
+
+if [[ "$key" == "latest" ]]; then
+  key=$(aws s3 ls "s3://$S3_BUCKET/db-backups/" | sort | tail -n 1 | awk '{print $4}')
+fi
+
+aws s3 cp "s3://$S3_BUCKET/db-backups/$key" "$tmpfile"
+gunzip -c "$tmpfile" | psql "$DATABASE_URL"
+rm "$tmpfile"


### PR DESCRIPTION
## Summary
- add nightly database backup script uploading to S3
- add restore script and document monthly recovery tests
- document media upload bucket versioning and backup procedure

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7403df628832a8d4522efd2cc7c12