### PR TITLE
feat: add feedback dialog and admin crash logs

### DIFF
--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+async function fetchCrashLogs() {
+  const org = process.env.SENTRY_ORG;
+  const project = process.env.SENTRY_PROJECT;
+  const token = process.env.SENTRY_AUTH_TOKEN;
+  if (!org || !project || !token) return [];
+  const res = await fetch(`https://sentry.io/api/0/projects/${org}/${project}/events/`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export default async function AdminPage() {
+  const events: any[] = await fetchCrashLogs();
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Crash Logs</h1>
+      {events.length === 0 && <p>No crash logs available.</p>}
+      <ul className="space-y-4">
+        {events.map((event) => (
+          <li key={event.id} className="border rounded p-4">
+            <div className="font-semibold">{event.title}</div>
+            <div className="text-sm text-gray-600">{event.eventID}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+async function createIssue(message: string, screenshot?: string) {
+  const repo = process.env.FEEDBACK_GITHUB_REPO;
+  const token = process.env.GITHUB_TOKEN;
+  if (!repo || !token) {
+    console.log('Feedback:', message, screenshot ? '(screenshot included)' : '');
+    return;
+  }
+  const [owner, repoName] = repo.split('/');
+  const body = {
+    title: `User Feedback`,
+    body: `${message}${screenshot ? `\n\n![screenshot](${screenshot})` : ''}`,
+  };
+  await fetch(`https://api.github.com/repos/${owner}/${repoName}/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github+json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const message = String(formData.get('message') || '');
+    const file = formData.get('screenshot') as Blob | null;
+    let screenshotBase64: string | undefined;
+    if (file) {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      screenshotBase64 = `data:${file.type};base64,${buffer.toString('base64')}`;
+    }
+    await createIssue(message, screenshotBase64);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Feedback error:', error);
+    return NextResponse.json({ error: 'Failed to submit feedback' }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ message: 'Feedback endpoint' });
+}

--- a/src/components/FeedbackDialog.tsx
+++ b/src/components/FeedbackDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
+  const [message, setMessage] = useState('');
+  const [screenshot, setScreenshot] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append('message', message);
+      if (screenshot) {
+        formData.append('screenshot', screenshot);
+      }
+
+      await fetch('/api/feedback', {
+        method: 'POST',
+        body: formData,
+      });
+
+      setMessage('');
+      setScreenshot(null);
+      onOpenChange(false);
+    } catch (err) {
+      console.error('Failed to submit feedback', err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Send Feedback</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Textarea
+            placeholder="Describe the issue or share your thoughts..."
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+          <Input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setScreenshot(e.target.files?.[0] ?? null)}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting || !message}>
+            Submit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add feedback dialog component to capture message and screenshot
- implement feedback API route logging to GitHub
- add admin dashboard page to display crash logs from Sentry

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7403e2a94832a929e197c885ceca9