### PR TITLE
feat: add OTA update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    env:
+      EAS_RELEASE_CHANNEL: ${{ github.ref == 'refs/heads/production' && 'production' || 'staging' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -31,3 +33,5 @@ jobs:
           cache: 'npm'
       - run: npm install
       - run: npm run build
+      - name: Publish OTA update
+        run: npx eas update --non-interactive --channel $EAS_RELEASE_CHANNEL

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,3 +33,23 @@ Use the scripts in the `scripts/` directory to automate deployment tasks:
 - `scripts/run-migrations.sh` – runs database migrations using Prisma.
 
 Ensure Docker and Node.js are installed on your deployment machine.
+
+## OTA Updates & Release Channels
+
+The CI workflow publishes over-the-air updates with Expo EAS. Commits to
+different branches are mapped to release channels:
+
+- `main` ➜ `staging`
+- `production` ➜ `production`
+
+### Rollback
+
+If an update causes issues, republish a previous commit to the affected
+channel:
+
+```bash
+eas update --non-interactive --channel <channel> --commit <commit-hash>
+```
+
+This will make the selected commit active again for all users on that
+release channel.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { headers, cookies } from "next/headers";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { QueryProvider } from "@/lib/query-provider";
+import { UpdateNotifier } from "@/lib/update-notifier";
 
 initSentry();
 
@@ -93,6 +94,7 @@ export default async function RootLayout({
                   <LanguageSwitcher />
                 </div>
                 {children}
+                <UpdateNotifier />
                 <Toaster />
               </QueryProvider>
             </AuthProvider>

--- a/src/lib/update-notifier.tsx
+++ b/src/lib/update-notifier.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { ToastAction } from "@/components/ui/toast";
+import { useToast } from "@/hooks/use-toast";
+import { checkExpoUpdate, reloadExpoUpdate } from "@/lib/updates";
+
+export function UpdateNotifier() {
+  const { toast } = useToast();
+
+  useEffect(() => {
+    async function check() {
+      const hasUpdate = await checkExpoUpdate();
+      if (hasUpdate) {
+        toast({
+          title: "Update available",
+          description: "A new version has been downloaded.",
+          action: (
+            <ToastAction altText="Reload" onClick={reloadExpoUpdate}>
+              Reload
+            </ToastAction>
+          ),
+        });
+      }
+    }
+    check();
+  }, [toast]);
+
+  return null;
+}

--- a/src/lib/updates.ts
+++ b/src/lib/updates.ts
@@ -1,0 +1,25 @@
+// Utilities for checking and applying OTA updates via Expo EAS
+// Uses dynamic imports so the web build does not require expo-updates
+
+export async function checkExpoUpdate(): Promise<boolean> {
+  try {
+    const Updates = await import(/* webpackIgnore: true */ 'expo-updates');
+    const update = await Updates.checkForUpdateAsync();
+    if (update.isAvailable) {
+      await Updates.fetchUpdateAsync();
+      return true;
+    }
+  } catch (err) {
+    console.warn('Failed to check for updates', err);
+  }
+  return false;
+}
+
+export async function reloadExpoUpdate() {
+  try {
+    const Updates = await import(/* webpackIgnore: true */ 'expo-updates');
+    await Updates.reloadAsync();
+  } catch (err) {
+    console.warn('Failed to reload update', err);
+  }
+}


### PR DESCRIPTION
## Summary
- add Expo OTA update utilities and notifier
- publish updates via release channels in CI
- document release channels and rollback steps

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a744eba5bc832a81398f2629a3fafd