### PR TITLE
Add Terraform infrastructure and CI deployment

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,30 @@
+name: Infra
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - production
+    paths:
+      - 'infra/**'
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v2
+
+      - name: Deploy infrastructure
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            production) ENV=prod ;;
+            staging) ENV=staging ;;
+            *) ENV=dev ;;
+          esac
+          ./infra/deploy.sh "$ENV"

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ test
 prompt
 
 server.log
+
+# Terraform
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.*

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENVIRONMENT="$1"
+
+if [[ -z "$ENVIRONMENT" ]]; then
+  echo "Usage: $0 <dev|staging|prod>" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+terraform init -backend-config="env/${ENVIRONMENT}.backend"
+terraform apply -var-file="env/${ENVIRONMENT}.tfvars" -auto-approve
+

--- a/infra/env/dev.backend
+++ b/infra/env/dev.backend
@@ -1,0 +1,4 @@
+bucket = "latest-os-terraform-state"
+key    = "dev/terraform.tfstate"
+region = "us-east-1"
+dynamodb_table = "latest-os-terraform-locks"

--- a/infra/env/dev.tfvars
+++ b/infra/env/dev.tfvars
@@ -1,0 +1,2 @@
+env        = "dev"
+aws_region = "us-east-1"

--- a/infra/env/prod.backend
+++ b/infra/env/prod.backend
@@ -1,0 +1,4 @@
+bucket = "latest-os-terraform-state"
+key    = "prod/terraform.tfstate"
+region = "us-east-1"
+dynamodb_table = "latest-os-terraform-locks"

--- a/infra/env/prod.tfvars
+++ b/infra/env/prod.tfvars
@@ -1,0 +1,2 @@
+env        = "prod"
+aws_region = "us-east-1"

--- a/infra/env/staging.backend
+++ b/infra/env/staging.backend
@@ -1,0 +1,4 @@
+bucket = "latest-os-terraform-state"
+key    = "staging/terraform.tfstate"
+region = "us-east-1"
+dynamodb_table = "latest-os-terraform-locks"

--- a/infra/env/staging.tfvars
+++ b/infra/env/staging.tfvars
@@ -1,0 +1,2 @@
+env        = "staging"
+aws_region = "us-east-1"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.0"
+  backend "s3" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket = "latest-os-${var.env}-example"
+  acl    = "private"
+
+  tags = {
+    Environment = var.env
+    ManagedBy   = "terraform"
+  }
+}
+

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,11 @@
+variable "env" {
+  description = "Deployment environment (dev, staging, prod)"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+


### PR DESCRIPTION
## Summary
- define Terraform config under infra/ with env-specific variables and remote state
- script and GitHub Actions workflow to deploy infra on branch pushes
- ignore Terraform state in git

## Testing
- `npm test`
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a744eda8fc832abbd06264db89f0ea