### PR TITLE
feat: add role-based access control

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -298,13 +298,23 @@ model User {
   last_login    DateTime?
   created_at    DateTime  @default(now())
   updated_at    DateTime  @updatedAt
+  role_id       String?
 
   couple        Couple       @relation(fields: [couple_id], references: [id], onDelete: Cascade)
   conversations Conversation[]
   voice_sessions VoiceSession[]
   notifications Notification[]
+  role          Role?        @relation(fields: [role_id], references: [id])
 
   @@map("users")
+}
+
+model Role {
+  id    String @id @default(cuid())
+  name  String @unique
+  users User[]
+
+  @@map("roles")
 }
 
 // Conversation sessions for AI coaching

--- a/src/app/(dashboard)/admin/page.tsx
+++ b/src/app/(dashboard)/admin/page.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { redirect } from 'next/navigation';
 
 async function fetchCrashLogs() {
   const org = process.env.SENTRY_ORG;
@@ -14,6 +17,11 @@ async function fetchCrashLogs() {
 }
 
 export default async function AdminPage() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    redirect('/');
+  }
+
   const events: any[] = await fetchCrashLogs();
   return (
     <div className="p-6 space-y-4">

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/ai-coaching/route.ts
+++ b/src/app/api/ai-coaching/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import ZAI from 'z-ai-web-dev-sdk';
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { userId, sessionType, context } = await request.json();
 

--- a/src/app/api/ai-suggestions/generate/route.ts
+++ b/src/app/api/ai-suggestions/generate/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/ai-suggestions/route.ts
+++ b/src/app/api/ai-suggestions/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/analytics/route.ts
+++ b/src/app/api/analytics/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const coupleId = searchParams.get('coupleId');
@@ -138,6 +145,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { coupleId, metricType, metricValue, targetValue, trend, contextData } = await request.json();
 

--- a/src/app/api/assign/route.ts
+++ b/src/app/api/assign/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/children/route.ts
+++ b/src/app/api/children/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/conversations/route.ts
+++ b/src/app/api/conversations/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const coupleId = searchParams.get('coupleId');
@@ -36,6 +43,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { coupleId, userId, title, messages, sessionSummary, duration, sentiment, topics, insights } = await request.json();
 

--- a/src/app/api/couples/route.ts
+++ b/src/app/api/couples/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/cultural/preferences/route.ts
+++ b/src/app/api/cultural/preferences/route.ts
@@ -1,8 +1,15 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import ZAI from 'z-ai-web-dev-sdk';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');
@@ -34,6 +41,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { userId, preferences } = await request.json();
 

--- a/src/app/api/cultural/route.ts
+++ b/src/app/api/cultural/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/family/activities/route.ts
+++ b/src/app/api/family/activities/route.ts
@@ -1,8 +1,15 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import ZAI from 'z-ai-web-dev-sdk';
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { childId, activityData, userId } = await request.json();
 
@@ -98,6 +105,11 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const childId = searchParams.get('childId');

--- a/src/app/api/family/children/route.ts
+++ b/src/app/api/family/children/route.ts
@@ -1,8 +1,15 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import ZAI from 'z-ai-web-dev-sdk';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');
@@ -85,6 +92,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { userId, childData } = await request.json();
 

--- a/src/app/api/family/route.ts
+++ b/src/app/api/family/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,3 +1,5 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
 async function createIssue(message: string, screenshot?: string) {
@@ -24,6 +26,11 @@ async function createIssue(message: string, screenshot?: string) {
 }
 
 export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const formData = await request.formData();
     const message = String(formData.get('message') || '');
@@ -42,5 +49,10 @@ export async function POST(request: Request) {
 }
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: 'Feedback endpoint' });
 }

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/grocery-lists/route.ts
+++ b/src/app/api/grocery-lists/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/kids-activities/route.ts
+++ b/src/app/api/kids-activities/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/meal-plans/route.ts
+++ b/src/app/api/meal-plans/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/memories/[id]/route.ts
+++ b/src/app/api/memories/[id]/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/memories/route.ts
+++ b/src/app/api/memories/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/milestones/route.ts
+++ b/src/app/api/milestones/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: 'Milestones API endpoint' });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: 'Milestone created' });
 }

--- a/src/app/api/notifications/push/route.ts
+++ b/src/app/api/notifications/push/route.ts
@@ -1,3 +1,5 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import webpush from 'web-push';
 import { getWebSubscriptions, getExpoPushTokens } from '../subscribe/route';
@@ -15,6 +17,11 @@ if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
 }
 
 export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const { title, body, url } = await req.json();
   const payload = JSON.stringify({ title, body, url });
 

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const coupleId = searchParams.get('coupleId');
@@ -45,6 +52,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { coupleId, userId, type, title, message, data } = await request.json();
 
@@ -82,6 +94,11 @@ export async function POST(request: NextRequest) {
 }
 
 export async function PATCH(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const notificationId = searchParams.get('id');

--- a/src/app/api/notifications/subscribe/route.ts
+++ b/src/app/api/notifications/subscribe/route.ts
@@ -1,3 +1,5 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 
 // In-memory stores for demonstration purposes. In production these would
@@ -6,6 +8,11 @@ const webSubscriptions: any[] = [];
 const expoPushTokens: string[] = [];
 
 export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const { subscription, token, platform } = await req.json();
 
   if (platform === 'web' && subscription) {

--- a/src/app/api/offline/route.ts
+++ b/src/app/api/offline/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/offline/sync/route.ts
+++ b/src/app/api/offline/sync/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { userId, syncData } = await request.json();
 
@@ -61,6 +68,11 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/privacy/route.ts
+++ b/src/app/api/privacy/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/privacy/settings/route.ts
+++ b/src/app/api/privacy/settings/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const userId = searchParams.get('userId');
@@ -37,6 +44,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { userId, settings } = await request.json();
 

--- a/src/app/api/rasa-balance/route.ts
+++ b/src/app/api/rasa-balance/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/relationship-health/route.ts
+++ b/src/app/api/relationship-health/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import ZAI from 'z-ai-web-dev-sdk';
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { action, userId, partnerId, healthData, timeframe } = await request.json();
     

--- a/src/app/api/rewards/route.ts
+++ b/src/app/api/rewards/route.ts
@@ -12,6 +12,11 @@ const createSchema = z.object({
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
   if (!session?.user?.couple?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -29,6 +34,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const session = await getServerSession(authOptions);
   if (!session?.user?.couple?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/rituals/route.ts
+++ b/src/app/api/rituals/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: 'Rituals API endpoint' });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: 'Ritual created' });
 }

--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/tasks/assign/route.ts
+++ b/src/app/api/tasks/assign/route.ts
@@ -1,9 +1,21 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextResponse } from "next/server";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "API endpoint" });
 }
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   return NextResponse.json({ message: "Operation completed" });
 }

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -19,6 +19,11 @@ const createSchema = z.object({
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
   if (!session?.user?.couple?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
@@ -47,6 +52,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const session = await getServerSession(authOptions);
   if (!session?.user?.couple?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/user/delete/route.ts
+++ b/src/app/api/user/delete/route.ts
@@ -14,6 +14,11 @@ async function sendDeletionEmail(email: string) {
 
 export async function POST() {
   const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
 
   if (!session?.user?.id || !session.user.email) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/user/export/route.ts
+++ b/src/app/api/user/export/route.ts
@@ -5,6 +5,11 @@ import { db } from '@/lib/db';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }

--- a/src/app/api/voice-interaction/route.ts
+++ b/src/app/api/voice-interaction/route.ts
@@ -15,6 +15,11 @@ const createSchema = z.object({
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const session = await getServerSession(authOptions);
   if (!session?.user?.id || !session.user.couple?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -32,6 +37,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   const session = await getServerSession(authOptions);
   if (!session?.user?.id || !session.user.couple?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/voice-sessions/route.ts
+++ b/src/app/api/voice-sessions/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 
 export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const coupleId = searchParams.get('coupleId');
@@ -36,6 +43,11 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { coupleId, userId, transcript, commands, duration, sentiment, emotions, sessionData } = await request.json();
 

--- a/src/app/api/wellness-programs/route.ts
+++ b/src/app/api/wellness-programs/route.ts
@@ -1,7 +1,14 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { NextRequest, NextResponse } from 'next/server';
 import ZAI from 'z-ai-web-dev-sdk';
 
 export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   try {
     const { action, programId, userId, partnerId, activityData } = await request.json();
     

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -21,7 +21,7 @@ export const authOptions: NextAuthOptions = {
 
         const user = await db.user.findUnique({
           where: { email: credentials.email },
-          include: { couple: true },
+          include: { couple: true, role: true },
         });
         if (!user) {
           return null;
@@ -36,6 +36,7 @@ export const authOptions: NextAuthOptions = {
           id: user.id,
           email: user.email,
           name: user.name,
+          role: user.role?.name,
           couple: user.couple,
         } as any;
       },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,16 @@
-export { default } from 'next-auth/middleware';
+import { withAuth } from 'next-auth/middleware';
+
+export default withAuth({
+  callbacks: {
+    authorized: ({ token, req }) => {
+      const { pathname } = req.nextUrl;
+      if (pathname.startsWith('/api') || pathname.startsWith('/admin')) {
+        return token?.user?.role === 'ADMIN';
+      }
+      return !!token;
+    },
+  },
+});
 
 export const config = {
   matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,16 @@
+import NextAuth, { DefaultSession, DefaultUser } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: DefaultUser & {
+      id: string;
+      role?: string | null;
+      couple?: any;
+    };
+  }
+
+  interface User extends DefaultUser {
+    role?: string | null;
+    couple?: any;
+  }
+}


### PR DESCRIPTION
## Summary
- add Role model and user relation in Prisma schema
- expose user role in auth/session types
- restrict API routes and admin dashboard to admin users

## Testing
- `npx prisma generate` *(fails: Failed to fetch the engine file - 403 Forbidden)*
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a744e2ce44832ab42eb869a15a46de