### PR TITLE
feat: set NEXTAUTH_URL for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
-      NEXTAUTH_SECRET: test-secret-for-ci
-      SENTRY_DSN: ""
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
+        NEXTAUTH_SECRET: test-secret-for-ci
+        NEXTAUTH_URL: http://localhost:3000
+        SENTRY_DSN: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -55,10 +56,11 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
-      NEXTAUTH_SECRET: test-secret-for-ci
-      SENTRY_DSN: ""
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
+        NEXTAUTH_SECRET: test-secret-for-ci
+        NEXTAUTH_URL: http://localhost:3000
+        SENTRY_DSN: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -21,10 +21,11 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
-      NEXTAUTH_SECRET: test-secret-for-ci
-      SENTRY_DSN: ""
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
+        NEXTAUTH_SECRET: test-secret-for-ci
+        NEXTAUTH_URL: http://localhost:3000
+        SENTRY_DSN: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- set NEXTAUTH_URL for CI lint/test and build steps
- ensure lighthouse workflow exports NEXTAUTH_URL

## Testing
- `npm test`
- `npx prisma generate` *(fails: Failed to fetch sha256 checksum at https://binaries.prisma.sh/... - 403 Forbidden)*
- `npx prisma db push` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... - 403 Forbidden)*
- `npm run build` *(fails: Can't resolve '@radix-ui/react-scroll-area')*

------
https://chatgpt.com/codex/tasks/task_e_68a8445f9c50832a8960164059a8d49b