### PR TITLE
ci: terminate node after lighthouse

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -35,10 +35,13 @@ jobs:
       - run: npx prisma generate
       - run: npx prisma db push
       - run: npm run build
-      - run: npm start & npx wait-on http://localhost:3000
+      - run: npm start & npx wait-on http://localhost:3000 --timeout=60000
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v11
         with:
           urls: http://localhost:3000
           configPath: ./lighthouserc.json
           budgetPath: ./lighthouse-budget.json
+      - name: Stop Node server
+        if: always()
+        run: pkill node


### PR DESCRIPTION
## Summary
- ensure Node server stops after Lighthouse CI
- add timeout to wait-on to fail fast when server doesn't start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a844628a34832a96b139114a128091