### PR TITLE
Expand Jest test matching to include non-__tests__ directories

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
     '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.jest.json' }],
   },
   testMatch: [
-    '<rootDir>/src/**/__tests__/**/*.(ts|tsx|js)'
+    '<rootDir>/src/**/*.(test|spec).(ts|tsx|js)'
   ],
   testPathIgnorePatterns: ['/node_modules/', '\\.e2e\\.(ts|tsx|js)$'],
   collectCoverageFrom: [


### PR DESCRIPTION
## Summary
- allow Jest to discover test and spec files anywhere under src

## Testing
- `npm test` *(fails: Cannot find module 'jest-axe' from 'src/components/FloatingActionButton.test.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68a882290e90832a8575bbdabeb6d90e