### PR TITLE
Add multi-region infrastructure and failover docs

### DIFF
--- a/docs/operations/multi-region.md
+++ b/docs/operations/multi-region.md
@@ -1,0 +1,18 @@
+# Multi-region Operations
+
+This application is deployed in two AWS regions. A primary stack runs in the main region with a secondary stack in another region for disaster recovery.
+
+## Failover procedure
+
+1. **Detect outage.** Confirm the primary region is unavailable by checking monitoring dashboards and health checks.
+2. **Promote the database replica.** In the secondary region promote the RDS read replica to master from the AWS console or with `aws rds promote-read-replica`.
+3. **Update DNS if needed.** CloudFront automatically fails over to the secondary S3 origin. If application endpoints require DNS changes, update Route53 records to point to resources in the secondary region.
+4. **Validate service.** Confirm the application is serving traffic from the secondary region and database writes succeed.
+
+## Returning to primary
+
+1. Restore the primary database from the promoted replica snapshot.
+2. Re-enable replication and point DNS records back to the primary CloudFront origin.
+3. Run `terraform apply` with the appropriate `tfvars` file to ensure infrastructure is back in sync.
+
+Regularly test this process to ensure multi-region failover works as expected.

--- a/infra/environments/dev.tfvars
+++ b/infra/environments/dev.tfvars
@@ -1,6 +1,7 @@
-env        = "dev"
-aws_region = "us-east-1"
-app_name   = "latest-os"
+env              = "dev"
+aws_region       = "us-east-1"
+secondary_region = "us-west-2"
+app_name         = "latest-os"
 
 vpc_cidr        = "10.0.0.0/16"
 public_subnets  = ["10.0.1.0/24", "10.0.2.0/24"]

--- a/infra/environments/prod.tfvars
+++ b/infra/environments/prod.tfvars
@@ -1,6 +1,7 @@
-env        = "prod"
-aws_region = "us-east-1"
-app_name   = "latest-os"
+env              = "prod"
+aws_region       = "us-east-1"
+secondary_region = "us-west-2"
+app_name         = "latest-os"
 
 vpc_cidr        = "10.1.0.0/16"
 public_subnets  = ["10.1.1.0/24", "10.1.2.0/24"]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,6 +14,11 @@ provider "aws" {
   region = var.aws_region
 }
 
+provider "aws" {
+  alias  = "secondary"
+  region = var.secondary_region
+}
+
 module "vpc" {
   source          = "./modules/vpc"
   vpc_cidr        = var.vpc_cidr
@@ -28,6 +33,13 @@ module "s3" {
   env         = var.env
 }
 
+module "s3_secondary" {
+  providers   = { aws = aws.secondary }
+  source      = "./modules/s3"
+  bucket_name = "${var.app_name}-${var.env}-data-${var.secondary_region}"
+  env         = var.env
+}
+
 module "rds" {
   source            = "./modules/rds"
   identifier        = "${var.app_name}-${var.env}-db"
@@ -37,6 +49,61 @@ module "rds" {
   db_name           = var.db_name
   username          = var.db_username
   password          = var.db_password
+}
+
+resource "aws_db_instance" "read_replica" {
+  provider            = aws.secondary
+  identifier          = "${var.app_name}-${var.env}-db-replica"
+  replicate_source_db = module.rds.db_instance_id
+  instance_class      = var.db_instance_class
+  publicly_accessible = false
+  skip_final_snapshot = true
+}
+
+resource "aws_cloudfront_distribution" "multi_region" {
+  enabled = true
+
+  origin {
+    domain_name = "${module.s3.bucket_name}.s3.${var.aws_region}.amazonaws.com"
+    origin_id   = "primary"
+    s3_origin_config {}
+  }
+
+  origin {
+    domain_name = "${module.s3_secondary.bucket_name}.s3.${var.secondary_region}.amazonaws.com"
+    origin_id   = "secondary"
+    s3_origin_config {}
+  }
+
+  origin_group {
+    origin_id = "group1"
+    failover_criteria {
+      status_codes = [403, 404, 500, 502, 503, 504]
+    }
+    member { origin_id = "primary" }
+    member { origin_id = "secondary" }
+  }
+
+  default_cache_behavior {
+    target_origin_id       = "group1"
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
 }
 
 module "ecs" {

--- a/infra/modules/rds/outputs.tf
+++ b/infra/modules/rds/outputs.tf
@@ -1,3 +1,7 @@
 output "db_endpoint" {
   value = aws_db_instance.this.address
 }
+
+output "db_instance_id" {
+  value = aws_db_instance.this.id
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -8,9 +8,19 @@ output "s3_bucket_arn" {
   value       = module.s3.bucket_arn
 }
 
+output "s3_secondary_bucket_name" {
+  description = "Name of the secondary region S3 bucket"
+  value       = module.s3_secondary.bucket_name
+}
+
 output "db_endpoint" {
   description = "RDS endpoint"
   value       = module.rds.db_endpoint
+}
+
+output "db_read_replica_endpoint" {
+  description = "Read replica endpoint"
+  value       = aws_db_instance.read_replica.address
 }
 
 output "vpc_id" {
@@ -21,6 +31,11 @@ output "vpc_id" {
 output "ecs_cluster_id" {
   description = "ECS cluster ID"
   value       = module.ecs.cluster_id
+}
+
+output "cdn_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.multi_region.domain_name
 }
 
 output "environment" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -10,6 +10,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "secondary_region" {
+  description = "Secondary AWS region for disaster recovery"
+  type        = string
+  default     = "us-west-2"
+}
+
 variable "app_name" {
   description = "Application name"
   type        = string


### PR DESCRIPTION
## Summary
- provision resources in an additional AWS region and configure read replica plus CloudFront failover
- expose new outputs for replica and CDN
- document disaster-recovery steps

## Testing
- `npm test`
- `npm run lint` *(fails: SyntaxError: Unexpected non-whitespace character after JSON at position 28)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ac6853a0832a9c9a18597141a8ea