### PR TITLE
feat: add analytics event pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ REDIS_URL="redis://localhost:6379"
 # VAPID keys for web push notifications (see https://developer.mozilla.org/docs/Web/API/Push_API)
 VAPID_PUBLIC_KEY="BCM3SzUBuqJH0UgCwumoryYD0_k2SKfXluVKT79rbN-D0zwwnhYpERxRjAV6diqGR2t41HCx2y_oakOMl0WgYX0"
 VAPID_PRIVATE_KEY="urlN0nhki1jP75PtgTB4Ac0M1GiB3X79zmVU2fSLPZY"
+
+# Analytics
+ANALYTICS_PROVIDER="segment" # or snowplow
+SEGMENT_WRITE_KEY="your-segment-write-key"
+SNOWPLOW_COLLECTOR_URL="https://collector.example.com"

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,28 @@
+# Analytics
+
+## Event Standardization
+Events emitted by the application are defined in `src/lib/analytics.ts` and follow a common naming scheme using snake_case.
+
+| Event | Properties |
+|-------|------------|
+| `user_signed_up` | `userId`, `plan` |
+| `user_logged_in` | `userId`, `method` |
+| `page_view` | `path`, `userId?` |
+| `task_completed` | `userId`, `taskId` |
+
+## Provider Integration
+Set environment variables in `.env` to choose an analytics provider:
+
+```
+ANALYTICS_PROVIDER=segment
+SEGMENT_WRITE_KEY=your-key
+SNOWPLOW_COLLECTOR_URL=https://collector.example.com
+```
+
+Events will be piped to Segment or Snowplow automatically via the `trackEvent` helper.
+
+## ETL to BigQuery or Redshift
+Both Segment and Snowplow provide native pipelines to forward collected data into warehouses such as BigQuery or Redshift. Configure the destination in the chosen provider's dashboard to enable automated ETL.
+
+## Dashboards
+Once data is available in the warehouse, use a BI tool (e.g. Looker, Data Studio, or Metabase) to build dashboards for activation, retention, and funnel analysis.

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,66 @@
+import { env } from './config';
+
+export const EVENTS = {
+  USER_SIGNED_UP: 'user_signed_up',
+  USER_LOGGED_IN: 'user_logged_in',
+  PAGE_VIEW: 'page_view',
+  TASK_COMPLETED: 'task_completed',
+} as const;
+
+export type EventName = (typeof EVENTS)[keyof typeof EVENTS];
+
+type BaseProps = {
+  userId?: string;
+  anonymousId?: string;
+  timestamp?: number;
+};
+
+type EventPayloads =
+  | { name: 'user_signed_up'; properties: BaseProps & { plan?: string } }
+  | { name: 'user_logged_in'; properties: BaseProps & { method?: string } }
+  | { name: 'page_view'; properties: BaseProps & { path: string } }
+  | { name: 'task_completed'; properties: BaseProps & { taskId: string } };
+
+async function sendToSegment(event: EventPayloads) {
+  if (!env.SEGMENT_WRITE_KEY) return;
+  const auth = Buffer.from(`${env.SEGMENT_WRITE_KEY}:`).toString('base64');
+  await fetch('https://api.segment.io/v1/track', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      event: event.name,
+      properties: event.properties,
+      userId: event.properties.userId,
+      anonymousId: event.properties.anonymousId,
+      timestamp: new Date(event.properties.timestamp ?? Date.now()).toISOString(),
+    }),
+  });
+}
+
+async function sendToSnowplow(event: EventPayloads) {
+  if (!env.SNOWPLOW_COLLECTOR_URL) return;
+  await fetch(env.SNOWPLOW_COLLECTOR_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(event),
+  });
+}
+
+export async function trackEvent(event: EventPayloads) {
+  switch (env.ANALYTICS_PROVIDER) {
+    case 'segment':
+      return sendToSegment(event);
+    case 'snowplow':
+      return sendToSnowplow(event);
+    default:
+      if (process.env.NODE_ENV !== 'production') {
+        console.debug('analytics event', event);
+      }
+  }
+}
+
+export type { EventPayloads as AnalyticsEvent };
+

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -29,6 +29,21 @@ const rawEnv = envsafe({
     allowEmpty: true,
     default: '',
   }),
+  ANALYTICS_PROVIDER: str({
+    desc: 'Analytics provider (segment or snowplow)',
+    default: '',
+    allowEmpty: true,
+  }),
+  SEGMENT_WRITE_KEY: str({
+    desc: 'Segment write key',
+    default: '',
+    allowEmpty: true,
+  }),
+  SNOWPLOW_COLLECTOR_URL: str({
+    desc: 'Snowplow collector URL',
+    default: '',
+    allowEmpty: true,
+  }),
 });
 
 const envSchema = z.object({
@@ -37,6 +52,9 @@ const envSchema = z.object({
   UNLEASH_URL: z.string().optional(),
   UNLEASH_CLIENT_KEY: z.string().optional(),
   SENTRY_DSN: z.string().optional().or(z.literal('')),
+  ANALYTICS_PROVIDER: z.string().optional(),
+  SEGMENT_WRITE_KEY: z.string().optional(),
+  SNOWPLOW_COLLECTOR_URL: z.string().optional(),
 });
 
 export const env = envSchema.parse(rawEnv);


### PR DESCRIPTION
## Summary
- add analytics helper with standard event names and trackEvent function
- integrate Segment or Snowplow via env-configured provider
- document analytics pipeline and dashboard guidance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9ac66bc08832a854240d40ed6e6cb