### PR TITLE
docs: add mobile beta distribution workflow

### DIFF
--- a/.github/workflows/mobile-beta.yml
+++ b/.github/workflows/mobile-beta.yml
@@ -1,0 +1,61 @@
+name: Mobile Beta Distribution
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Build iOS and submit to TestFlight
+        env:
+          EAS_TOKEN: ${{ secrets.EAS_TOKEN }}
+          APPLE_APP_ID: ${{ secrets.APPLE_APP_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          npx eas build --platform ios --non-interactive --profile preview
+          npx eas submit --platform ios --non-interactive \
+            --apple-app-id "$APPLE_APP_ID" \
+            --team-id "$APPLE_TEAM_ID" \
+            --apple-app-specific-password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --group "beta-testers"
+      - name: Build Android and submit to Google Play Internal
+        env:
+          EAS_TOKEN: ${{ secrets.EAS_TOKEN }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          npx eas build --platform android --non-interactive --profile preview
+          echo "$GOOGLE_SERVICE_ACCOUNT_KEY" > service-account.json
+          npx eas submit --platform android --non-interactive \
+            --key-file service-account.json \
+            --track internal \
+            --group "beta-testers"
+      - name: Open feedback issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {data: issue} = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Beta feedback for ${context.sha.substring(0,7)}`,
+              body: 'Collect tester feedback and bug reports here.',
+              labels: ['beta-feedback']
+            });
+            core.notice(`Feedback issue: ${issue.html_url}`);
+
+  promote:
+    needs: build-and-upload
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - run: echo "Release approved. Promote builds in store dashboards."

--- a/docs/mobile/beta-testing.md
+++ b/docs/mobile/beta-testing.md
@@ -1,0 +1,45 @@
+# Beta Testing Distribution
+
+This guide explains how to distribute mobile builds to TestFlight and Google Play internal testing, automate uploads from CI, invite beta testers, collect feedback, and require sign‑offs before promoting to production.
+
+## TestFlight Setup
+
+1. Create an App Store Connect app for iOS.
+2. Define a beta tester group called `beta-testers` and invite testers by email.
+3. Generate an App Store Connect API key and store it in the repository secrets as `APPLE_APP_ID`, `APPLE_TEAM_ID`, and an App‑specific password `APPLE_APP_SPECIFIC_PASSWORD`.
+
+## Google Play Internal Testing
+
+1. Create an application in the Google Play Console.
+2. Set up an **Internal testing** track and a tester list named `beta-testers`.
+3. Download a service account JSON key and add it as the `GOOGLE_SERVICE_ACCOUNT_KEY` secret.
+
+## Continuous Integration Uploads
+
+The workflow at `.github/workflows/mobile-beta.yml` builds and uploads new commits to both stores:
+
+- Uses Expo EAS to build iOS and Android artifacts.
+- Submits builds to TestFlight and Google Play internal tracks.
+- Adds testers from the `beta-testers` group automatically.
+- Opens a GitHub issue labeled `beta-feedback` for collecting reports.
+
+Required secrets:
+
+- `EAS_TOKEN`
+- `APPLE_APP_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `GOOGLE_SERVICE_ACCOUNT_KEY`
+
+## Feedback and Sign‑Offs
+
+Each beta upload creates a feedback issue. Testers report bugs and suggestions in that issue. Production promotion is gated by a manual approval step that requires team sign‑off in GitHub Actions before the `promote` job runs.
+
+## Promoting to Production
+
+Once feedback is addressed and the release is approved:
+
+1. Approve the **Promote** job in the workflow run to allow publishing to production tracks.
+2. In App Store Connect and Google Play Console, review the submitted build and publish it to production.
+
+This process ensures only vetted releases reach end users.


### PR DESCRIPTION
## Summary
- document TestFlight and Google Play internal testing setup
- add CI workflow to build, upload, and gather beta feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a98bd91d0c832ab73f72f2325ded2b