### PR TITLE
chore(ci): add terraform validate step

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -40,6 +40,9 @@ jobs:
             -backend-config="key=terraform.tfstate" \
             -backend-config="region=us-east-1"
 
+      - name: Terraform Validate
+        run: terraform validate
+
       - name: Terraform Format
         run: terraform fmt -check
 


### PR DESCRIPTION
## Summary
- add terraform validate to infra workflow

## Testing
- `npm install --legacy-peer-deps` *(fails: No matching version found for postcss)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab806e1d4832a9d2126e4081aa3f7