### PR TITLE
chore(ci): remove npm cache clearing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
         run: |
           timeout 30 bash -c 'until pg_isready -h localhost -p 5432; do sleep 1; done'
           timeout 30 bash -c 'until redis-cli -h localhost -p 6379 ping; do sleep 1; done'
-      - name: Clear npm cache
-        run: npm cache clean --force
       - name: Verify package files sync
         run: |
           echo "Checking package.json and package-lock.json sync..."
@@ -136,8 +134,6 @@ jobs:
         run: |
           timeout 30 bash -c 'until pg_isready -h localhost -p 5432; do sleep 1; done'
           timeout 30 bash -c 'until redis-cli -h localhost -p 6379 ping; do sleep 1; done'
-      - name: Clear npm cache
-        run: npm cache clean --force
       - name: Verify package files sync
         run: |
           echo "Checking package.json and package-lock.json sync..."


### PR DESCRIPTION
## Summary
- remove redundant npm cache clearing step from CI workflow
- ensure setup-node retains npm caching

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aab8084480832ab2863ccf985aa6b1