### PR TITLE
Capture server PID in Lighthouse workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -67,8 +67,8 @@ jobs:
         run: npm run build
       - name: Start server and wait
         run: |
-          npm start &
-          SERVER_PID=$!
+          npm start & SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> $GITHUB_ENV
           npx wait-on http://localhost:3000 --timeout=60000
           echo "Server started with PID: $SERVER_PID"
       - name: Run Lighthouse CI
@@ -79,7 +79,4 @@ jobs:
           budgetPath: ./lighthouse-budget.json
       - name: Stop Node server
         if: always()
-        run: |
-          pkill -f "tsx server.ts" || true
-          pkill -f "node.*server" || true
-          sleep 2
+        run: kill $SERVER_PID


### PR DESCRIPTION
## Summary
- store Lighthouse server PID in `$GITHUB_ENV`
- replace process name shutdown with `kill $SERVER_PID`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: No matching version found for postcss@^8.5.11)*

------
https://chatgpt.com/codex/tasks/task_e_68aab8056d04832a82dac62e158d5839